### PR TITLE
Improve type checking

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,11 @@ Minitest::TestTask.create do |t|
   t.test_globs = ["test/**/*_test.rb"]
 end
 
+desc "Test Compiler output"
+task :compiler do
+  sh "./test/test_type_checker.sh"
+end
+
 require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
@@ -21,4 +26,4 @@ task :sorbet do
   sh "bundle exec srb tc"
 end
 
-task default: %i[rubocop:autocorrect_all sorbet test]
+task default: %i[rubocop:autocorrect_all sorbet test compiler]

--- a/lib/typed/failure.rb
+++ b/lib/typed/failure.rb
@@ -7,11 +7,20 @@ module Typed
     extend T::Sig
     extend T::Generic
 
-    Payload = type_member
+    Payload = type_member { { fixed: T.untyped } }
     Error = type_member
 
     sig { override.returns(T.nilable(Error)) }
     attr_reader :error
+
+    sig do
+      type_parameters(:T)
+        .params(error: T.nilable(T.type_parameter(:T)))
+        .returns(Typed::Failure[T.type_parameter(:T)])
+    end
+    def self.new(error: nil)
+      super(error: error)
+    end
 
     sig { params(error: T.nilable(Error)).void }
     def initialize(error: nil)

--- a/lib/typed/success.rb
+++ b/lib/typed/success.rb
@@ -8,10 +8,19 @@ module Typed
     extend T::Generic
 
     Payload = type_member
-    Error = type_member
+    Error = type_member { { fixed: T.untyped } }
 
     sig { override.returns(T.nilable(Payload)) }
     attr_reader :payload
+
+    sig do
+      type_parameters(:T)
+        .params(payload: T.nilable(T.type_parameter(:T)))
+        .returns(Typed::Success[T.type_parameter(:T)])
+    end
+    def self.new(payload: nil)
+      super(payload: payload)
+    end
 
     sig { params(payload: T.nilable(Payload)).void }
     def initialize(payload: nil)

--- a/sorbet/config
+++ b/sorbet/config
@@ -2,3 +2,4 @@
 .
 --ignore=tmp/
 --ignore=vendor/
+--ignore=test/test_data/

--- a/test/test_data/success.out
+++ b/test/test_data/success.out
@@ -1,0 +1,14 @@
+test/test_data/success.rb:14: Expected `Typed::Result[Integer, String]` but found `T.any(Typed::Success[String], Typed::Failure[String])` for method result type https://srb.help/7005
+    14 |  end
+          ^^^
+  Expected `Typed::Result[Integer, String]` for result type of method `test`:
+    test/test_data/success.rb:8:
+     8 |  def test(should_succeed)
+          ^^^^^^^^^^^^^^^^^^^^^^^^
+  Got `T.any(Typed::Success[String], Typed::Failure[String])` originating from:
+    test/test_data/success.rb:10:
+    10 |      Typed::Success.new(payload: "1")
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    test/test_data/success.rb:12:
+    12 |      Typed::Failure.new(error: "")
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/test_data/success.rb
+++ b/test/test_data/success.rb
@@ -1,0 +1,15 @@
+# typed: true
+# frozen_string_literal: true
+
+class TestGenerics
+  extend T::Sig
+
+  sig { params(should_succeed: T::Boolean).returns(Typed::Result[Integer, String]) }
+  def test(should_succeed)
+    if should_succeed
+      Typed::Success.new(payload: "1")
+    else
+      Typed::Failure.new(error: "")
+    end
+  end
+end

--- a/test/test_type_checker.sh
+++ b/test/test_type_checker.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for file in test/test_data/*.rb; do
+  filename=$(basename "$file" .rb)
+  diff <(bundle exec srb tc --no-error-count --file "$file" 2>&1) "test/test_data/$filename.out"
+done

--- a/test/typed/failure_test.rb
+++ b/test/typed/failure_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 
 class FailureTest < Minitest::Test
   def setup
-    @failure = Typed::Failure[String, String].new(error: "Something bad")
+    @failure = Typed::Failure.new(error: "Something bad")
     @failure_without_error = Typed::Failure.new
   end
 

--- a/test/typed/success_test.rb
+++ b/test/typed/success_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 
 class SuccessTest < Minitest::Test
   def setup
-    @success = Typed::Success[String, String].new(payload: "Testing")
+    @success = Typed::Success.new(payload: "Testing")
     @success_without_payload = Typed::Success.new
   end
 


### PR DESCRIPTION
## What problem is this trying to solve?

While introducing `sorbet-result` in our codebase, I realised that `srb tc` was not checking the generics on return types as expected. Take this code as an example:

```ruby
sig { params(x: T::Boolean).returns(Typed::Result[Integer, String]) }
def test(x)
  x ?
    Typed::Success.new(payload: '1') :
    Typed::Failure.new(error: '')
end
```

This code is supposed to return either a `Success` with `Integer` payload, or a `Failure` with `String` error.
However, despite the code initialising `Typed::Success` with a `String` payload, I got no error from the static typechecker and no runtime error because generics are erased at runtime... surprise!

My first attempt to solve this was to be more specific with the return types:

```ruby
sig { params(x: T::Boolean).returns(Typed::Result[Integer, String]) }
def test(x)
  x ?
    Typed::Success[Integer, T.untyped].new(payload: '1') :
    Typed::Failure[T.untyped, String].new(error: '')
end
```

Although this DOES cause a `srb tc` error, it has multiple downsides:
* I need to explicitly specify the types: this can be easily forgotten, causing the type mismatch to fail silently as we've seen above
* Even if I do remember to specify the types, I need to add a `T.untyped` for error or payload (on Success and Failure respectively) because they have no restrictions on the generic classes.

## Summary

Improve `Typed::Success` and `Typed::Failure`.

These generic classes will now only require a single `type_member` (Payload for success, Error for failure), so it's not necessary to pass both when specifying one of the type_members.

Moreover, the `new` method is overridden using a generic signature so that the type of the argument will define the return type of the initialized class.

In practice, before this change `Typed::Success.new(payload: 'hi')` had type `Typed::Success[T.untyped, T.untyped]`. If you wanted to help sorbet type this properly, you'd have had to explicitly use `Typed::Success[String, T.untyped].new(payload: 'hi')`.

After this change, not only you can now simply say `Typed::Success[String]` without the need to specify `T.untyped` for the Error type_member, but sorbet will also automatically infer this type based on the argument `payload`.

This all applies to `Typed::Failure` as well.