### PR TITLE
Remove keyword arguments from `Success` and `Failure` initializers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,8 @@ Style/StringLiteralsInInterpolation:
 
 Layout/LineLength:
   Max: 120
+
+Lint/UselessMethodDefinition:
+  Exclude:
+    - lib/typed/failure.rb
+    - lib/typed/success.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *Breaking* Make `Typed::Success#Error` and `Typed::Failure#Payload` fixed to `T.untyped`. This allows to specify the other type_member only when using generics. See #8 for more details
 - *Breaking* Remove `T.nilable` from `Payload` and `Error` parameters in `Typed::Success.new` and `Typed::Failure.new`. Nilability will now need to be specified in the generic type. This also means that you'll need to use the new `.blank` instead of `.new` when you want to create a `Typed::Success` or `Typed::Failure` with a `nil` payload or error.
+- *Breaking* Change `Typed::Success` and `Typed::Failure` initialize arguments from keyword to positional.
 - Improve `Typed::Success.new` and `Typed::Failure.new` to make them generic methods and automatically infer the type of the `payload` and `error` arguments. See #8 for more details
 
 ## [0.2.1] - 2023-05-18

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Generally, it's nice to have a payload with results, and it's nice to have more 
 sig { params(resource_id: Integer).returns(Typed::Result[Float, String]) }
 def call_api(resource_id)
   # Something bad happened
-  return Typed::Failure.new(error: "I couldn't do it!") # => Typed::Failure[String]
+  return Typed::Failure.new("I couldn't do it!") # => Typed::Failure[String]
 
   # Some other bad thing happened
-  return Typed::Failure.new(error: "I couldn't do it for another reason!") # => Typed::Failure[String]
+  return Typed::Failure.new("I couldn't do it for another reason!") # => Typed::Failure[String]
 
   # Success!
-  Typed::Success.new(payload: 1.12) # => Typed::Success[Float]
+  Typed::Success.new(1.12) # => Typed::Success[Float]
 end
 ```
 
@@ -108,13 +108,13 @@ Railway Oriented Programming, which comes from the functional programming commun
 sig { params(resource_id: Integer).returns(Typed::Result[Float, String]) }
 def call_api(resource_id)
   # something bad happened
-  return Typed::Failure.new(error: "I couldn't do it!")
+  return Typed::Failure.new("I couldn't do it!")
 
   # something other bad thing happened
-  return Typed::Failure.new(error: "I couldn't do it for another reason!")
+  return Typed::Failure.new("I couldn't do it for another reason!")
 
   # Success!
-  Typed::Success.new(payload: 1.12)
+  Typed::Success.new(1.12)
 end
 ```
 

--- a/lib/typed/failure.rb
+++ b/lib/typed/failure.rb
@@ -18,17 +18,17 @@ module Typed
         .params(error: T.type_parameter(:T))
         .returns(Typed::Failure[T.type_parameter(:T)])
     end
-    def self.new(error:)
-      super(error: error)
+    def self.new(error)
+      super(error)
     end
 
     sig { returns(Typed::Failure[NilClass]) }
     def self.blank
-      new(error: nil)
+      new(nil)
     end
 
     sig { params(error: Error).void }
-    def initialize(error:)
+    def initialize(error)
       @error = error
       super()
     end

--- a/lib/typed/success.rb
+++ b/lib/typed/success.rb
@@ -18,17 +18,17 @@ module Typed
         .params(payload: T.type_parameter(:T))
         .returns(Typed::Success[T.type_parameter(:T)])
     end
-    def self.new(payload:)
-      super(payload: payload)
+    def self.new(payload)
+      super(payload)
     end
 
     sig { returns(Typed::Success[NilClass]) }
     def self.blank
-      new(payload: nil)
+      new(nil)
     end
 
     sig { params(payload: Payload).void }
-    def initialize(payload:)
+    def initialize(payload)
       @payload = payload
       super()
     end

--- a/test/test_data/failure.out
+++ b/test/test_data/failure.out
@@ -10,17 +10,17 @@ test/test_data/failure.rb:14: Expected `Typed::Result[Integer, String]` but foun
     10 |      Typed::Success.new(1)
               ^^^^^^^^^^^^^^^^^^^^^
     test/test_data/failure.rb:12:
-    12 |      Typed::Failure.new(error: 1)
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 |      Typed::Failure.new(1)
+              ^^^^^^^^^^^^^^^^^^^^^
 
 test/test_data/failure.rb:26: Expected `Integer` but found `String("error")` for argument `error` https://srb.help/7002
-    26 |    Typed::Failure[Integer].new(error: "error")
-                                               ^^^^^^^
+    26 |    Typed::Failure[Integer].new("error")
+                                        ^^^^^^^
   Expected `Integer` for argument `error` of method `Typed::Failure#initialize`:
     ./lib/typed/failure.rb:30:
     30 |    sig { params(error: Error).void }
                          ^^^^^
   Got `String("error")` originating from:
     test/test_data/failure.rb:26:
-    26 |    Typed::Failure[Integer].new(error: "error")
-                                               ^^^^^^^
+    26 |    Typed::Failure[Integer].new("error")
+                                        ^^^^^^^

--- a/test/test_data/failure.out
+++ b/test/test_data/failure.out
@@ -7,8 +7,8 @@ test/test_data/failure.rb:14: Expected `Typed::Result[Integer, String]` but foun
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Got `T.any(Typed::Success[Integer], Typed::Failure[Integer])` originating from:
     test/test_data/failure.rb:10:
-    10 |      Typed::Success.new(payload: 1)
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    10 |      Typed::Success.new(1)
+              ^^^^^^^^^^^^^^^^^^^^^
     test/test_data/failure.rb:12:
     12 |      Typed::Failure.new(error: 1)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/test_data/failure.rb
+++ b/test/test_data/failure.rb
@@ -9,13 +9,13 @@ class TestGenerics
     if should_succeed
       Typed::Success.new(1)
     else
-      Typed::Failure.new(error: 1)
+      Typed::Failure.new(1)
     end
   end
 
   sig { returns(Typed::Failure[String]) }
   def test_inferred_error_type
-    failure = Typed::Failure.new(error: "error")
+    failure = Typed::Failure.new("error")
 
     T.assert_type!(failure.error, String)
     failure
@@ -23,6 +23,6 @@ class TestGenerics
 
   sig { returns(Typed::Failure[Integer]) }
   def test_explicit_error_type
-    Typed::Failure[Integer].new(error: "error")
+    Typed::Failure[Integer].new("error")
   end
 end

--- a/test/test_data/failure.rb
+++ b/test/test_data/failure.rb
@@ -7,7 +7,7 @@ class TestGenerics
   sig { params(should_succeed: T::Boolean).returns(Typed::Result[Integer, String]) }
   def test_generic_initializer(should_succeed)
     if should_succeed
-      Typed::Success.new(payload: 1)
+      Typed::Success.new(1)
     else
       Typed::Failure.new(error: 1)
     end

--- a/test/test_data/flow_typing.rb
+++ b/test/test_data/flow_typing.rb
@@ -7,7 +7,7 @@ class TestGenerics
   sig { params(should_succeed: T::Boolean).returns(Typed::Result[Integer, String]) }
   def do_something(should_succeed)
     if should_succeed
-      Typed::Success.new(payload: 123)
+      Typed::Success.new(123)
     else
       Typed::Failure.new(error: "")
     end

--- a/test/test_data/flow_typing.rb
+++ b/test/test_data/flow_typing.rb
@@ -9,7 +9,7 @@ class TestGenerics
     if should_succeed
       Typed::Success.new(123)
     else
-      Typed::Failure.new(error: "")
+      Typed::Failure.new("")
     end
   end
 

--- a/test/test_data/success.out
+++ b/test/test_data/success.out
@@ -10,8 +10,8 @@ test/test_data/success.rb:14: Expected `Typed::Result[Integer, String]` but foun
     10 |      Typed::Success.new("1")
               ^^^^^^^^^^^^^^^^^^^^^^^
     test/test_data/success.rb:12:
-    12 |      Typed::Failure.new(error: "")
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 |      Typed::Failure.new("")
+              ^^^^^^^^^^^^^^^^^^^^^^
 
 test/test_data/success.rb:26: Expected `Integer` but found `String("success")` for argument `payload` https://srb.help/7002
     26 |    Typed::Success[Integer].new("success")

--- a/test/test_data/success.out
+++ b/test/test_data/success.out
@@ -7,20 +7,20 @@ test/test_data/success.rb:14: Expected `Typed::Result[Integer, String]` but foun
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Got `T.any(Typed::Success[String], Typed::Failure[String])` originating from:
     test/test_data/success.rb:10:
-    10 |      Typed::Success.new(payload: "1")
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    10 |      Typed::Success.new("1")
+              ^^^^^^^^^^^^^^^^^^^^^^^
     test/test_data/success.rb:12:
     12 |      Typed::Failure.new(error: "")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 test/test_data/success.rb:26: Expected `Integer` but found `String("success")` for argument `payload` https://srb.help/7002
-    26 |    Typed::Success[Integer].new(payload: "success")
-                                                 ^^^^^^^^^
+    26 |    Typed::Success[Integer].new("success")
+                                        ^^^^^^^^^
   Expected `Integer` for argument `payload` of method `Typed::Success#initialize`:
     ./lib/typed/success.rb:30:
     30 |    sig { params(payload: Payload).void }
                          ^^^^^^^
   Got `String("success")` originating from:
     test/test_data/success.rb:26:
-    26 |    Typed::Success[Integer].new(payload: "success")
-                                                 ^^^^^^^^^
+    26 |    Typed::Success[Integer].new("success")
+                                        ^^^^^^^^^

--- a/test/test_data/success.rb
+++ b/test/test_data/success.rb
@@ -9,7 +9,7 @@ class TestGenerics
     if should_succeed
       Typed::Success.new("1")
     else
-      Typed::Failure.new(error: "")
+      Typed::Failure.new("")
     end
   end
 

--- a/test/test_data/success.rb
+++ b/test/test_data/success.rb
@@ -7,7 +7,7 @@ class TestGenerics
   sig { params(should_succeed: T::Boolean).returns(Typed::Result[Integer, String]) }
   def test_generic_initializer(should_succeed)
     if should_succeed
-      Typed::Success.new(payload: "1")
+      Typed::Success.new("1")
     else
       Typed::Failure.new(error: "")
     end
@@ -15,7 +15,7 @@ class TestGenerics
 
   sig { returns(Typed::Success[String]) }
   def test_inferred_payload_type
-    success = Typed::Success.new(payload: "success")
+    success = Typed::Success.new("success")
 
     T.assert_type!(success.payload, String)
     success
@@ -23,6 +23,6 @@ class TestGenerics
 
   sig { returns(Typed::Success[Integer]) }
   def test_explicit_payload_type
-    Typed::Success[Integer].new(payload: "success")
+    Typed::Success[Integer].new("success")
   end
 end

--- a/test/typed/failure_test.rb
+++ b/test/typed/failure_test.rb
@@ -6,7 +6,13 @@ require "test_helper"
 class FailureTest < Minitest::Test
   def setup
     @failure = Typed::Failure.new("Something bad")
-    @failure_without_error = Typed::Failure.blank
+    @failure_without_error = Typed::Failure.new(nil)
+  end
+
+  def test_blank_is_convenience_for_nil_error
+    failure = Typed::Failure.blank
+
+    assert_nil failure.error
   end
 
   def test_it_is_failure

--- a/test/typed/failure_test.rb
+++ b/test/typed/failure_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 
 class FailureTest < Minitest::Test
   def setup
-    @failure = Typed::Failure.new(error: "Something bad")
+    @failure = Typed::Failure.new("Something bad")
     @failure_without_error = Typed::Failure.blank
   end
 

--- a/test/typed/success_test.rb
+++ b/test/typed/success_test.rb
@@ -6,7 +6,13 @@ require "test_helper"
 class SuccessTest < Minitest::Test
   def setup
     @success = Typed::Success.new("Testing")
-    @success_without_payload = Typed::Success.blank
+    @success_without_payload = Typed::Success.new(nil)
+  end
+
+  def test_blank_is_convenience_for_nil_payload
+    success = Typed::Success.blank
+
+    assert_nil success.payload
   end
 
   def test_it_is_success

--- a/test/typed/success_test.rb
+++ b/test/typed/success_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 
 class SuccessTest < Minitest::Test
   def setup
-    @success = Typed::Success.new(payload: "Testing")
+    @success = Typed::Success.new("Testing")
     @success_without_payload = Typed::Success.blank
   end
 


### PR DESCRIPTION
* Removes the need to specify `payload:` and `error:` keyword arguments when initializing a `Success` or `Failure`

cc @iMacTia 