### PR TITLE
Fix test_type_checker.sh return type consistency

### DIFF
--- a/test/test_type_checker.sh
+++ b/test/test_type_checker.sh
@@ -3,4 +3,11 @@
 for file in test/test_data/*.rb; do
   filename=$(basename "$file" .rb)
   diff <(bundle exec srb tc --no-error-count --file "$file" 2>&1) "test/test_data/$filename.out"
+  if [[ $? -ne 0 ]]; then
+    fail=1
+  fi
 done
+
+if [[ $fail == 1 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

`test_type_checker.sh` loops through the files in `test/test_data` and runs `srb tc` on each of them before comparing the output with the expected output using `diff`.

The return status of the script is currently the return status of the last iteration, which means if a `diff` command fails it won't be spot unless it's the last one.

This commit addressed that, by introducing a `fail` variable that keep tracks if ANY `diff` command fails, and reflects that in the overall return status.