### PR TITLE
Introduce `payload_or` method for returning default values

### DIFF
--- a/lib/typed/failure.rb
+++ b/lib/typed/failure.rb
@@ -57,5 +57,15 @@ module Typed
     def and_then(&_block)
       self
     end
+
+    sig do
+      override
+        .type_parameters(:Fallback)
+        .params(value: T.type_parameter(:Fallback))
+        .returns(T.any(Payload, T.type_parameter(:Fallback)))
+    end
+    def payload_or(value)
+      value
+    end
   end
 end

--- a/lib/typed/result.rb
+++ b/lib/typed/result.rb
@@ -32,5 +32,13 @@ module Typed
         .returns(T.any(Result[T.type_parameter(:U), T.type_parameter(:T)], Result[T.type_parameter(:U), Error]))
     end
     def and_then(&_block); end
+
+    sig do
+      abstract
+        .type_parameters(:Fallback)
+        .params(value: T.type_parameter(:Fallback))
+        .returns(T.any(Payload, T.type_parameter(:Fallback)))
+    end
+    def payload_or(value); end
   end
 end

--- a/lib/typed/success.rb
+++ b/lib/typed/success.rb
@@ -57,5 +57,15 @@ module Typed
     def and_then(&block)
       block.call(payload)
     end
+
+    sig do
+      override
+        .type_parameters(:Fallback)
+        .params(value: T.type_parameter(:Fallback))
+        .returns(T.any(Payload, T.type_parameter(:Fallback)))
+    end
+    def payload_or(value) # rubocop:disable Lint/UnusedMethodArgument
+      payload
+    end
   end
 end

--- a/test/test_data/failure.out
+++ b/test/test_data/failure.out
@@ -24,3 +24,18 @@ test/test_data/failure.rb:26: Expected `Integer` but found `String("error")` for
     test/test_data/failure.rb:26:
     26 |    Typed::Failure[Integer].new("error")
                                         ^^^^^^^
+
+test/test_data/failure.rb:33: Method `upcase` does not exist on `Integer` https://srb.help/7003
+    33 |    success.payload_or(1).upcase
+                                  ^^^^^^
+  Got `Integer` originating from:
+    test/test_data/failure.rb:33:
+    33 |    success.payload_or(1).upcase
+            ^^^^^^^^^^^^^^^^^^^^^
+  Did you mean `phase`? Use `-a` to autocorrect
+    test/test_data/failure.rb:33: Replace with `phase`
+    33 |    success.payload_or(1).upcase
+                                  ^^^^^^
+    https://github.com/sorbet/sorbet/tree/6cfdcc56f3b81d8024b6423167d745f4bfd92258/rbi/core/integer.rbi#L921: Defined here
+     921 |  def phase(); end
+            ^^^^^^^^^^^

--- a/test/test_data/failure.rb
+++ b/test/test_data/failure.rb
@@ -25,4 +25,11 @@ class TestGenerics
   def test_explicit_error_type
     Typed::Failure[Integer].new("error")
   end
+
+  sig { void }
+  def test_payload_or
+    success = Typed::Failure.new("success")
+
+    success.payload_or(1).upcase
+  end
 end

--- a/test/test_data/success.out
+++ b/test/test_data/success.out
@@ -24,3 +24,18 @@ test/test_data/success.rb:26: Expected `Integer` but found `String("success")` f
     test/test_data/success.rb:26:
     26 |    Typed::Success[Integer].new("success")
                                         ^^^^^^^^^
+
+test/test_data/success.rb:33: Method `upcase` does not exist on `Integer` component of `T.any(String, Integer)` https://srb.help/7003
+    33 |    success.payload_or(1).upcase
+                                  ^^^^^^
+  Got `T.any(String, Integer)` originating from:
+    test/test_data/success.rb:33:
+    33 |    success.payload_or(1).upcase
+            ^^^^^^^^^^^^^^^^^^^^^
+  Did you mean `phase`? Use `-a` to autocorrect
+    test/test_data/success.rb:33: Replace with `phase`
+    33 |    success.payload_or(1).upcase
+                                  ^^^^^^
+    https://github.com/sorbet/sorbet/tree/6cfdcc56f3b81d8024b6423167d745f4bfd92258/rbi/core/integer.rbi#L921: Defined here
+     921 |  def phase(); end
+            ^^^^^^^^^^^

--- a/test/test_data/success.rb
+++ b/test/test_data/success.rb
@@ -25,4 +25,11 @@ class TestGenerics
   def test_explicit_payload_type
     Typed::Success[Integer].new("success")
   end
+
+  sig { void }
+  def test_payload_or
+    success = Typed::Success.new("success")
+
+    success.payload_or(1).upcase
+  end
 end

--- a/test/typed/failure_test.rb
+++ b/test/typed/failure_test.rb
@@ -39,4 +39,8 @@ class FailureTest < Minitest::Test
     assert_equal(@failure, @failure.and_then { "Should not be called" })
     assert_equal(@failure_without_error, @failure_without_error.and_then { "Should not be called" })
   end
+
+  def test_payload_or_returns_value
+    assert_equal(2, @failure.payload_or(2))
+  end
 end

--- a/test/typed/success_test.rb
+++ b/test/typed/success_test.rb
@@ -39,4 +39,8 @@ class SuccessTest < Minitest::Test
     assert_equal("Testing", @success.and_then { |payload| Typed::Success.new(payload) }.payload)
     assert_equal(@success_without_payload, @success_without_payload.and_then { |_payload| @success_without_payload })
   end
+
+  def test_payload_or_returns_payload
+    assert_equal("Testing", @success.payload_or(2))
+  end
 end


### PR DESCRIPTION
Introduces a payload or default value method for easier use of result unwrapping.

Closes #16 