### PR TITLE
Adds on_error method for easier error handling during chaining

### DIFF
--- a/lib/typed/failure.rb
+++ b/lib/typed/failure.rb
@@ -60,11 +60,11 @@ module Typed
 
     sig do
       override
-        .params(blk: T.proc.params(arg0: Error).void)
+        .params(block: T.proc.params(arg0: Error).void)
         .returns(T.self_type)
     end
-    def on_error(&blk)
-      blk.call(error)
+    def on_error(&block)
+      block.call(error)
       self
     end
 

--- a/lib/typed/failure.rb
+++ b/lib/typed/failure.rb
@@ -60,6 +60,16 @@ module Typed
 
     sig do
       override
+        .params(blk: T.proc.params(arg0: Error).void)
+        .returns(T.self_type)
+    end
+    def on_error(&blk)
+      blk.call(error)
+      self
+    end
+
+    sig do
+      override
         .type_parameters(:Fallback)
         .params(value: T.type_parameter(:Fallback))
         .returns(T.any(Payload, T.type_parameter(:Fallback)))

--- a/lib/typed/result.rb
+++ b/lib/typed/result.rb
@@ -35,10 +35,10 @@ module Typed
 
     sig do
       abstract
-        .params(blk: T.proc.params(arg0: Error).void)
+        .params(block: T.proc.params(arg0: Error).void)
         .returns(T.self_type)
     end
-    def on_error(&blk); end
+    def on_error(&block); end
 
     sig do
       abstract

--- a/lib/typed/result.rb
+++ b/lib/typed/result.rb
@@ -35,6 +35,13 @@ module Typed
 
     sig do
       abstract
+        .params(blk: T.proc.params(arg0: Error).void)
+        .returns(T.self_type)
+    end
+    def on_error(&blk); end
+
+    sig do
+      abstract
         .type_parameters(:Fallback)
         .params(value: T.type_parameter(:Fallback))
         .returns(T.any(Payload, T.type_parameter(:Fallback)))

--- a/lib/typed/success.rb
+++ b/lib/typed/success.rb
@@ -60,6 +60,15 @@ module Typed
 
     sig do
       override
+        .params(blk: T.proc.params(arg0: Error).void)
+        .returns(T.self_type)
+    end
+    def on_error(&blk) # rubocop:disable Lint/UnusedMethodArgument
+      self
+    end
+
+    sig do
+      override
         .type_parameters(:Fallback)
         .params(value: T.type_parameter(:Fallback))
         .returns(T.any(Payload, T.type_parameter(:Fallback)))

--- a/lib/typed/success.rb
+++ b/lib/typed/success.rb
@@ -60,10 +60,10 @@ module Typed
 
     sig do
       override
-        .params(_blk: T.proc.params(arg0: Error).void)
+        .params(_block: T.proc.params(arg0: Error).void)
         .returns(T.self_type)
     end
-    def on_error(&_blk)
+    def on_error(&_block)
       self
     end
 

--- a/lib/typed/success.rb
+++ b/lib/typed/success.rb
@@ -60,20 +60,20 @@ module Typed
 
     sig do
       override
-        .params(blk: T.proc.params(arg0: Error).void)
+        .params(_blk: T.proc.params(arg0: Error).void)
         .returns(T.self_type)
     end
-    def on_error(&blk) # rubocop:disable Lint/UnusedMethodArgument
+    def on_error(&_blk)
       self
     end
 
     sig do
       override
         .type_parameters(:Fallback)
-        .params(value: T.type_parameter(:Fallback))
+        .params(_value: T.type_parameter(:Fallback))
         .returns(T.any(Payload, T.type_parameter(:Fallback)))
     end
-    def payload_or(value) # rubocop:disable Lint/UnusedMethodArgument
+    def payload_or(_value)
       payload
     end
   end

--- a/test/test_data/failure.rb
+++ b/test/test_data/failure.rb
@@ -32,4 +32,11 @@ class TestGenerics
 
     success.payload_or(1).upcase
   end
+
+  sig { void }
+  def test_passed_on_error_type
+    Typed::Failure.new("error").on_error do |error|
+      T.assert_type!(error, String)
+    end
+  end
 end

--- a/test/typed/failure_test.rb
+++ b/test/typed/failure_test.rb
@@ -40,6 +40,13 @@ class FailureTest < Minitest::Test
     assert_equal(@failure_without_error, @failure_without_error.and_then { "Should not be called" })
   end
 
+  def test_on_error_calls_block_and_returns_self
+    ran_block = T.let(false, T::Boolean)
+
+    assert_equal(@failure, @failure.on_error { ran_block = true })
+    assert(ran_block)
+  end
+
   def test_payload_or_returns_value
     assert_equal(2, @failure.payload_or(2))
   end

--- a/test/typed/failure_test.rb
+++ b/test/typed/failure_test.rb
@@ -40,11 +40,11 @@ class FailureTest < Minitest::Test
     assert_equal(@failure_without_error, @failure_without_error.and_then { "Should not be called" })
   end
 
-  def test_on_error_calls_block_and_returns_self
-    ran_block = T.let(false, T::Boolean)
+  def test_on_error_calls_block_with_error_and_returns_self
+    captured_error = T.let(nil, T.nilable(String))
 
-    assert_equal(@failure, @failure.on_error { ran_block = true })
-    assert(ran_block)
+    assert_equal(@failure, @failure.on_error { |error| captured_error = error })
+    assert_equal("Something bad", captured_error)
   end
 
   def test_payload_or_returns_value

--- a/test/typed/success_test.rb
+++ b/test/typed/success_test.rb
@@ -40,6 +40,10 @@ class SuccessTest < Minitest::Test
     assert_equal(@success_without_payload, @success_without_payload.and_then { |_payload| @success_without_payload })
   end
 
+  def test_on_error_does_not_call_block_and_returns_self
+    assert_equal(@success, @success.on_error { raise "Ran on_error block on Success type" })
+  end
+
   def test_payload_or_returns_payload
     assert_equal("Testing", @success.payload_or(2))
   end


### PR DESCRIPTION
Introduces an `on_error` method for easier error handling when chaining `Result`s. It will only execute the block if called on a `Failure` type and the `Error` is given to the block for processing.

Example usages here include logging or capturing an error in error monitoring software.

Closes #15 