### PR TITLE
feat: implement `Result#either` for easier result unpacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ res = retrieve_user(user_id)
 
 If the above chain does not fail, the `puts` statement is never run. If the chain does yield a `Failure`, the `puts` block is executed and the `Failure` is ultimately returned.
 
+### Transforming Results
+
+Once you're done chaining operations that can yield results, you'll typically want to take different actions based on Success or Failure. There are a few methods to aid this.
+
+`#payload_or(fallback)` can be used to return either the `Payload` type when Success or the provided value.
+
+`#either(on_success, on_failure)` allows you to provide two procs to be run on success or on failure. These receive the payload and error if not nil, but will not receive any arguments if they are nil.
+
 ## Why use Results?
 
 Let's say you're working on a method that reaches out to an API and fetches a resource. We hope to get a successful response and continue on in our program, but you can imagine several scenarios where we don't get that response: our authentication could fail, the server could return a 5XX response code, or the resource we were querying could have moved or not exist any more.

--- a/lib/typed/failure.rb
+++ b/lib/typed/failure.rb
@@ -72,13 +72,24 @@ module Typed
       override
         .type_parameters(:S, :F)
         .params(
-          on_success: T.proc.params(arg0: Payload).returns(T.type_parameter(:S)),
-          on_failure: T.proc.params(arg0: Error).returns(T.type_parameter(:F))
+          on_success: T.any(
+            T.proc.returns(T.type_parameter(:S)),
+            T.proc.params(arg0: Payload).returns(T.type_parameter(:S))
+          ),
+          on_failure: T.any(
+            T.proc.returns(T.type_parameter(:F)),
+            T.proc.params(arg0: Error).returns(T.type_parameter(:F))
+          )
         )
         .returns(T.any(T.type_parameter(:S), T.type_parameter(:F)))
     end
     def either(on_success, on_failure)
-      on_failure.call(error)
+      case error
+      when nil
+        T.cast(on_failure, T.proc.returns(T.type_parameter(:F))).call
+      else
+        T.cast(on_failure, T.proc.params(arg0: Error).returns(T.type_parameter(:F))).call(error)
+      end
     end
 
     sig do

--- a/lib/typed/failure.rb
+++ b/lib/typed/failure.rb
@@ -70,6 +70,19 @@ module Typed
 
     sig do
       override
+        .type_parameters(:S, :F)
+        .params(
+          on_success: T.proc.params(arg0: Payload).returns(T.type_parameter(:S)),
+          on_failure: T.proc.params(arg0: Error).returns(T.type_parameter(:F))
+        )
+        .returns(T.any(T.type_parameter(:S), T.type_parameter(:F)))
+    end
+    def either(on_success, on_failure)
+      on_failure.call(error)
+    end
+
+    sig do
+      override
         .type_parameters(:Fallback)
         .params(value: T.type_parameter(:Fallback))
         .returns(T.any(Payload, T.type_parameter(:Fallback)))

--- a/lib/typed/result.rb
+++ b/lib/typed/result.rb
@@ -50,8 +50,14 @@ module Typed
       abstract
         .type_parameters(:S, :F)
         .params(
-          on_success: T.proc.params(arg0: Payload).returns(T.type_parameter(:S)),
-          on_failure: T.proc.params(arg0: Error).returns(T.type_parameter(:F))
+          on_success: T.any(
+            T.proc.returns(T.type_parameter(:S)),
+            T.proc.params(arg0: Payload).returns(T.type_parameter(:S))
+          ),
+          on_failure: T.any(
+            T.proc.returns(T.type_parameter(:F)),
+            T.proc.params(arg0: Error).returns(T.type_parameter(:F))
+          )
         )
         .returns(T.any(T.type_parameter(:S), T.type_parameter(:F)))
     end

--- a/lib/typed/result.rb
+++ b/lib/typed/result.rb
@@ -48,6 +48,18 @@ module Typed
 
     sig do
       abstract
+        .type_parameters(:S, :F)
+        .params(
+          on_success: T.proc.params(arg0: Payload).returns(T.type_parameter(:S)),
+          on_failure: T.proc.params(arg0: Error).returns(T.type_parameter(:F))
+        )
+        .returns(T.any(T.type_parameter(:S), T.type_parameter(:F)))
+    end
+    def either(on_success, on_failure)
+    end
+
+    sig do
+      abstract
         .type_parameters(:Fallback)
         .params(value: T.type_parameter(:Fallback))
         .returns(T.any(Payload, T.type_parameter(:Fallback)))

--- a/lib/typed/success.rb
+++ b/lib/typed/success.rb
@@ -69,6 +69,19 @@ module Typed
 
     sig do
       override
+        .type_parameters(:S, :F)
+        .params(
+          on_success: T.proc.params(arg0: Payload).returns(T.type_parameter(:S)),
+          on_failure: T.proc.params(arg0: Error).returns(T.type_parameter(:F))
+        )
+        .returns(T.any(T.type_parameter(:S), T.type_parameter(:F)))
+    end
+    def either(on_success, on_failure)
+      on_success.call(payload)
+    end
+
+    sig do
+      override
         .type_parameters(:Fallback)
         .params(_value: T.type_parameter(:Fallback))
         .returns(T.any(Payload, T.type_parameter(:Fallback)))

--- a/lib/typed/success.rb
+++ b/lib/typed/success.rb
@@ -71,13 +71,24 @@ module Typed
       override
         .type_parameters(:S, :F)
         .params(
-          on_success: T.proc.params(arg0: Payload).returns(T.type_parameter(:S)),
-          on_failure: T.proc.params(arg0: Error).returns(T.type_parameter(:F))
+          on_success: T.any(
+            T.proc.returns(T.type_parameter(:S)),
+            T.proc.params(arg0: Payload).returns(T.type_parameter(:S))
+          ),
+          on_failure: T.any(
+            T.proc.returns(T.type_parameter(:F)),
+            T.proc.params(arg0: Error).returns(T.type_parameter(:F))
+          )
         )
         .returns(T.any(T.type_parameter(:S), T.type_parameter(:F)))
     end
     def either(on_success, on_failure)
-      on_success.call(payload)
+      case payload
+      when nil
+        T.cast(on_success, T.proc.returns(T.type_parameter(:S))).call
+      else
+        T.cast(on_success, T.proc.params(arg0: Payload).returns(T.type_parameter(:S))).call(payload)
+      end
     end
 
     sig do

--- a/test/test_data/either.rb
+++ b/test/test_data/either.rb
@@ -1,0 +1,54 @@
+# typed: true
+# frozen_string_literal: true
+
+class TestGenerics
+  extend T::Sig
+
+  sig { params(should_succeed: T::Boolean).returns(Typed::Result[Integer, String]) }
+  def do_something(should_succeed)
+    if should_succeed
+      Typed::Success.new(123)
+    else
+      Typed::Failure.new("")
+    end
+  end
+
+  sig { returns(T.any(Float, Integer)) }
+  def test_either
+    do_something(true)
+      .either(
+        ->(payload) { payload.to_f },
+        ->(error) { error.to_i }
+      )
+  end
+
+  # TODO: Sorbet erases the type parameter generic return types,
+  # so `lhs` and `rhs` are both `T.untyped` inside the body here
+  sig { returns(T.any(Float, Integer)) }
+  def test_return_type_check
+    lhs = do_something(true)
+      .either(
+        ->(payload) { payload.to_f },
+        ->(error) { error.to_i }
+      )
+
+    rhs = do_something(true)
+      .either(
+        ->(payload) { payload.to_f },
+        ->(error) { error.to_i }
+      )
+
+    T.assert_type!(lhs, Float)
+    T.assert_type!(rhs, Integer)
+  end
+
+  # TODO: I would like Sorbet would know this is unreachable, but it currently doesn't
+  sig { returns(String) }
+  def test_unreachability
+    Typed::Failure.new("")
+      .either(
+        ->(_payload) { "unreachable" },
+        ->(error) { error }
+      )
+  end
+end

--- a/test/typed/failure_test.rb
+++ b/test/typed/failure_test.rb
@@ -59,8 +59,8 @@ class FailureTest < Minitest::Test
     assert_equal(
       "No error",
       @failure_without_error.either(
-        ->(_payload) { raise "Ran on_success proc on Failure type" },
-        ->(_error) { "No error" }
+        -> { raise "Ran on_success proc on Failure type" },
+        -> { "No error" }
       )
     )
   end

--- a/test/typed/failure_test.rb
+++ b/test/typed/failure_test.rb
@@ -47,6 +47,24 @@ class FailureTest < Minitest::Test
     assert_equal("Something bad", captured_error)
   end
 
+  def test_either_runs_on_failure
+    assert_equal(
+      "Error was Something bad",
+      @failure.either(
+        ->(payload) { raise "Ran on_success proc on Failure type" },
+        ->(error) { "Error was #{error}" }
+      )
+    )
+
+    assert_equal(
+      "No error",
+      @failure_without_error.either(
+        ->(_payload) { raise "Ran on_success proc on Failure type" },
+        ->(_error) { "No error" }
+      )
+    )
+  end
+
   def test_payload_or_returns_value
     assert_equal(2, @failure.payload_or(2))
   end

--- a/test/typed/success_test.rb
+++ b/test/typed/success_test.rb
@@ -56,8 +56,8 @@ class SuccessTest < Minitest::Test
     assert_equal(
       "No payload",
       @success_without_payload.either(
-        ->(_payload) { "No payload" },
-        ->(_error) { raise "Ran on_failure proc on Success type" }
+        -> { "No payload" },
+        -> { raise "Ran on_failure proc on Success type" }
       )
     )
   end

--- a/test/typed/success_test.rb
+++ b/test/typed/success_test.rb
@@ -44,6 +44,24 @@ class SuccessTest < Minitest::Test
     assert_equal(@success, @success.on_error { raise "Ran on_error block on Success type" })
   end
 
+  def test_either_runs_on_success
+    assert_equal(
+      "Payload was Testing",
+      @success.either(
+        ->(payload) { "Payload was #{payload}" },
+        ->(error) { raise "Ran on_failure proc on Success type" }
+      )
+    )
+
+    assert_equal(
+      "No payload",
+      @success_without_payload.either(
+        ->(_payload) { "No payload" },
+        ->(_error) { raise "Ran on_failure proc on Success type" }
+      )
+    )
+  end
+
   def test_payload_or_returns_payload
     assert_equal("Testing", @success.payload_or(2))
   end


### PR DESCRIPTION
This is largely inspired by [Dry Monad's `either` implementation](https://dry-rb.org/gems/dry-monads/1.3/result/#code-either-code) on their Result type. 

This method accepts two procs and runs the first if the result is a success and the second if it's a failure. `nil` payloads and errors are not passed to the given procs.

One downside is the runtime type erasure of the generic parameters that each proc returns. I'm going to add an issue to investigate if we can prevent the runtime return type to be seen as T.untyped. Maybe @iMacTia has some ideas for how to improve that 😄 