### PR TITLE
Fix README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ result = call_api(1)
 
 result.success? # => true on success, false on failure
 result.failure? # => true on failure, false on success
-result.payload # => raises error on failure, payload type on failure
+result.payload # => raises error on failure, payload type on success
 result.error # => raises error on success, error type on failure
 result.payload_or("fallback") # => returns payload on success, given value on failure
 


### PR DESCRIPTION
`#result` returns the payload type on success