### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   tapioca:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/maxveldink/sorbet-result/security/code-scanning/3](https://github.com/maxveldink/sorbet-result/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow (`actions/checkout` and `ruby/setup-ruby`), the workflow likely only needs read access to the repository contents. Therefore, the `permissions` block should be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
